### PR TITLE
6주차 세미나 구현 과제

### DIFF
--- a/sixthAssignment/build.gradle
+++ b/sixthAssignment/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	//JWT
@@ -37,6 +37,7 @@ dependencies {
 
 	//Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	//Multipart file
 	implementation("software.amazon.awssdk:bom:2.21.0")

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/JwtAuthenticationFilter.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/JwtAuthenticationFilter.java
@@ -35,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final String token = getJwtFromRequest(request);
 
             if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
-                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+                Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
                 setAuthentication(request, memberId);
             }
         } catch (Exception exception) {

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthToken.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthToken.java
@@ -1,0 +1,7 @@
+package org.sopt.common.auth.dto;
+
+public record AuthToken(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthToken.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthToken.java
@@ -1,7 +1,0 @@
-package org.sopt.common.auth.dto;
-
-public record AuthToken(
-        String accessToken,
-        String refreshToken
-) {
-}

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthTokenSet.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthTokenSet.java
@@ -1,0 +1,16 @@
+package org.sopt.common.auth.dto;
+
+public record AuthTokenSet(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static AuthTokenSet of(String accessToken, String refreshToken) {
+        return new AuthTokenSet(accessToken, refreshToken);
+    }
+
+    public enum Type {
+        ACCESS_TOKEN,
+        REFRESH_TOKEN
+    }
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/jwt/JwtTokenProvider.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/jwt/JwtTokenProvider.java
@@ -3,7 +3,9 @@ package org.sopt.common.auth.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
-import org.sopt.common.auth.dto.AuthToken;
+import org.sopt.common.auth.UserAuthentication;
+import org.sopt.common.auth.dto.AuthTokenSet;
+import org.sopt.common.auth.redis.service.TokenService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -17,42 +19,45 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private static final String USER_ID = "userId";
-
     private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
     private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
 
+    private final TokenService tokenService;
     @Value("${jwt.secret}")
     private String JWT_SECRET;
 
-    public AuthToken issueToken(final Authentication authentication) {
-        return new AuthToken(
-                issueAccessToken(authentication),
-                issueRefreshToken(authentication)
-        );
-    }
+    public String issueToken(Long memberId, AuthTokenSet.Type type) {
+        Authentication authentication = UserAuthentication.createUserAuthentication(memberId);
 
-    private String issueAccessToken(final Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
-    }
+        if (type == AuthTokenSet.Type.ACCESS_TOKEN)
+            return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
 
-    private String issueRefreshToken(final Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
-    }
+        String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
+        tokenService.save(memberId, refreshToken);
 
+        return refreshToken;
+    }
 
     public String generateToken(Authentication authentication, Long tokenExpirationTime) {
-        final Date now = new Date();
-        final Claims claims = Jwts.claims()
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
-
-        claims.put(USER_ID, authentication.getPrincipal());
+        Claims claims = generateClaims(authentication, tokenExpirationTime);
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
                 .setClaims(claims) // Claim
                 .signWith(getSigningKey()) // Signature
                 .compact();
+    }
+
+    private Claims generateClaims(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        claims.put(USER_ID, authentication.getPrincipal());
+
+        return claims;
     }
 
     private SecretKey getSigningKey() {
@@ -84,7 +89,7 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
-    public Long getUserFromJwt(String token) {
+    public Long getMemberIdFromToken(String token) {
         Claims claims = getBody(token);
         return Long.valueOf(claims.get(USER_ID).toString());
     }

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/jwt/JwtTokenProvider.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package org.sopt.common.auth.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import org.sopt.common.auth.dto.AuthToken;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -23,12 +24,18 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String JWT_SECRET;
 
+    public AuthToken issueToken(final Authentication authentication) {
+        return new AuthToken(
+                issueAccessToken(authentication),
+                issueRefreshToken(authentication)
+        );
+    }
 
-    public String issueAccessToken(final Authentication authentication) {
+    private String issueAccessToken(final Authentication authentication) {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
-    public String issueRefreshToken(final Authentication authentication) {
+    private String issueRefreshToken(final Authentication authentication) {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/redis/domain/Token.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/redis/domain/Token.java
@@ -1,0 +1,21 @@
+package org.sopt.common.auth.redis.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(timeToLive = 60 * 60 * 24 * 1000L * 14)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Token {
+
+    @Id
+    private Long memberId;
+
+    @Indexed
+    private String refreshToken;
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/redis/repository/TokenRepository.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/redis/repository/TokenRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.common.auth.redis.repository;
+
+import org.sopt.common.auth.redis.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+
+    Optional<Token> findByMemberId(Long memberId);
+    Optional<Token> findByMemberIdAndRefreshToken(Long memberId, String refreshToken);
+    Optional<Token> findByRefreshToken(String refreshToken);
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/auth/redis/service/TokenService.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/auth/redis/service/TokenService.java
@@ -1,0 +1,22 @@
+package org.sopt.common.auth.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.auth.redis.domain.Token;
+import org.sopt.common.auth.redis.repository.TokenRepository;
+import org.sopt.common.exception.NotFoundException;
+import org.sopt.common.exception.message.ErrorMessage;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+
+    public void save(Long memberId, String refreshToken) {
+        tokenRepository.save(Token.builder()
+                .memberId(memberId)
+                .refreshToken(refreshToken)
+                .build());
+    }
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberJoinResponse.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberJoinResponse.java
@@ -1,14 +1,17 @@
 package org.sopt.common.dto.response;
 
+import org.sopt.common.auth.dto.AuthToken;
+
 public record MemberJoinResponse(
         String accessToken,
+        String refreshToken,
         String userId
 ) {
 
     public static MemberJoinResponse of(
-            String accessToken,
+            AuthToken token,
             String userId
     ) {
-        return new MemberJoinResponse(accessToken, userId);
+        return new MemberJoinResponse(token.accessToken(), token.refreshToken(), userId);
     }
 }

--- a/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberJoinResponse.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberJoinResponse.java
@@ -1,6 +1,6 @@
 package org.sopt.common.dto.response;
 
-import org.sopt.common.auth.dto.AuthToken;
+import org.sopt.common.auth.dto.AuthTokenSet;
 
 public record MemberJoinResponse(
         String accessToken,
@@ -9,7 +9,7 @@ public record MemberJoinResponse(
 ) {
 
     public static MemberJoinResponse of(
-            AuthToken token,
+            AuthTokenSet token,
             String userId
     ) {
         return new MemberJoinResponse(token.accessToken(), token.refreshToken(), userId);

--- a/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberTokenRefreshResponse.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/dto/response/MemberTokenRefreshResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.common.dto.response;
+
+public record MemberTokenRefreshResponse(
+        String accessToken
+) {
+
+    public static MemberTokenRefreshResponse of(String accessToken) {
+        return new MemberTokenRefreshResponse(accessToken);
+    }
+}

--- a/sixthAssignment/src/main/java/org/sopt/common/exception/message/ErrorMessage.java
+++ b/sixthAssignment/src/main/java/org/sopt/common/exception/message/ErrorMessage.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND_BY_REFRESH_TOKEN_EXCEPTION(HttpStatus.NOT_FOUND.value(), "리프레시 토큰에 해당하는 사용자가 존재하지 않습니다."),
     BLOG_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
     ;

--- a/sixthAssignment/src/main/java/org/sopt/config/RedisConfig.java
+++ b/sixthAssignment/src/main/java/org/sopt/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package org.sopt.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/sixthAssignment/src/main/java/org/sopt/controller/MemberController.java
+++ b/sixthAssignment/src/main/java/org/sopt/controller/MemberController.java
@@ -5,10 +5,13 @@ import org.sopt.common.dto.request.MemberJoinRequest;
 import org.sopt.common.dto.response.MemberGetAllResponse;
 import org.sopt.common.dto.response.MemberGetResponse;
 import org.sopt.common.dto.response.MemberJoinResponse;
+import org.sopt.common.dto.response.MemberTokenRefreshResponse;
 import org.sopt.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,11 +31,20 @@ public class MemberController {
                 .body(memberJoinResponse);
     }
 
+    @GetMapping("/refresh")
+    public ResponseEntity<MemberTokenRefreshResponse> refreshAccessToken(
+            @RequestHeader("Authorization") String refreshToken
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(memberService.refreshAccessToken(refreshToken));
+    }
+
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberGetResponse> findMemberById(
             @PathVariable Long memberId
     ) {
-        return ResponseEntity.ok(memberService.findMemberById(memberId));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(MemberGetResponse.of(memberService.findById(memberId)));
     }
 
     @DeleteMapping("/{memberId}")

--- a/sixthAssignment/src/main/java/org/sopt/service/MemberService.java
+++ b/sixthAssignment/src/main/java/org/sopt/service/MemberService.java
@@ -1,13 +1,14 @@
 package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.common.auth.UserAuthentication;
-import org.sopt.common.auth.dto.AuthToken;
+import org.sopt.common.auth.dto.AuthTokenSet;
+import org.sopt.common.auth.redis.service.TokenService;
 import org.sopt.common.dto.request.MemberJoinRequest;
 import org.sopt.common.dto.response.MemberJoinResponse;
 import org.sopt.common.auth.jwt.JwtTokenProvider;
+import org.sopt.common.dto.response.MemberTokenRefreshResponse;
+import org.sopt.common.exception.UnauthorizedException;
 import org.sopt.domain.Member;
-import org.sopt.common.dto.request.MemberCreateRequest;
 import org.sopt.common.dto.response.MemberGetAllResponse;
 import org.sopt.common.dto.response.MemberGetResponse;
 import org.sopt.common.exception.NotFoundException;
@@ -16,7 +17,12 @@ import org.sopt.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
 import java.util.List;
+
+import static org.sopt.common.auth.dto.AuthTokenSet.Type.ACCESS_TOKEN;
+import static org.sopt.common.auth.dto.AuthTokenSet.Type.REFRESH_TOKEN;
+import static org.sopt.common.auth.jwt.JwtValidationType.VALID_JWT;
 
 @Service
 @RequiredArgsConstructor
@@ -24,28 +30,32 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
 
     @Transactional
     public MemberJoinResponse createMember(
             MemberJoinRequest request
     ) {
         Member member = memberRepository.save(request.toEntity());
-        AuthToken token = getToken(member.getId());
+        AuthTokenSet token = getTokenSet(member.getId());
 
         return MemberJoinResponse.of(token, member.getId().toString());
     }
 
-    private AuthToken getToken(Long memberId) {
-        UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
-
-        return jwtTokenProvider.issueToken(authentication);
+    private AuthTokenSet getTokenSet(Long memberId) {
+        return AuthTokenSet.of(
+                jwtTokenProvider.issueToken(memberId, ACCESS_TOKEN),
+                jwtTokenProvider.issueToken(memberId, REFRESH_TOKEN)
+        );
     }
 
-    public MemberGetResponse findMemberById(
-            Long memberId
-    ) {
-        return MemberGetResponse.of(memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)));
+    public MemberTokenRefreshResponse refreshAccessToken(String refreshToken) {
+        if (jwtTokenProvider.validateToken(refreshToken) != VALID_JWT)
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+        String accessToken = jwtTokenProvider.issueToken(memberId, ACCESS_TOKEN);
+        return MemberTokenRefreshResponse.of(accessToken);
     }
 
     public Member findById(Long memberId) {

--- a/sixthAssignment/src/main/java/org/sopt/service/MemberService.java
+++ b/sixthAssignment/src/main/java/org/sopt/service/MemberService.java
@@ -2,6 +2,7 @@ package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.common.auth.UserAuthentication;
+import org.sopt.common.auth.dto.AuthToken;
 import org.sopt.common.dto.request.MemberJoinRequest;
 import org.sopt.common.dto.response.MemberJoinResponse;
 import org.sopt.common.auth.jwt.JwtTokenProvider;
@@ -25,29 +26,19 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public String createMemberWithoutAuth(
-            MemberCreateRequest request
-    ) {
-        Member member = request.toEntity();
-        memberRepository.save(member);
-
-        return member.getId().toString();
-    }
-
-    @Transactional
     public MemberJoinResponse createMember(
             MemberJoinRequest request
     ) {
         Member member = memberRepository.save(request.toEntity());
-        String accessToken = getToken(member.getId());
+        AuthToken token = getToken(member.getId());
 
-        return MemberJoinResponse.of(accessToken, member.getId().toString());
+        return MemberJoinResponse.of(token, member.getId().toString());
     }
 
-    private String getToken(Long memberId) {
+    private AuthToken getToken(Long memberId) {
         UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
 
-        return jwtTokenProvider.issueAccessToken(authentication);
+        return jwtTokenProvider.issueToken(authentication);
     }
 
     public MemberGetResponse findMemberById(


### PR DESCRIPTION
# 🧑‍🎤 요구사항
- [x] 가입 시 리프레쉬 토큰을 생성하여 사용자에게 반환한다.
- [x] 리프레쉬 토큰을 Redis 인메모리 해쉬로 관리한다.
- [x] 요청 헤더에 입력된 리프레쉬 토큰을 기반으로 액세스 토큰을 재발급한다.

&nbsp;
&nbsp;

# 👩🏼‍🌾 주요 코드
### 1. 토큰 DTO에 대한 타입 분류
https://github.com/NOW-SOPT-SERVER/jinkonu/blob/c40028b6484dbf77f618c71b5e69ce34fe045ef3/sixthAssignment/src/main/java/org/sopt/common/auth/dto/AuthTokenSet.java#L3-L16

- DTO 안에 enum을 두어 '액세스 토큰'과 '리프레쉬 토큰'을 구분했습니다.

&nbsp;
&nbsp;

https://github.com/NOW-SOPT-SERVER/jinkonu/blob/c40028b6484dbf77f618c71b5e69ce34fe045ef3/sixthAssignment/src/main/java/org/sopt/common/auth/jwt/JwtTokenProvider.java#L29-L39

- 덕분에 `JwtTokenProvider`에서 '토큰 발급'이라는 동일한 역할을 수행하는 메서드를 제거할 수 있었습니다.

&nbsp;
&nbsp;

### 2. 리프레쉬 토큰으로부터 액세스 토큰 재발급
https://github.com/NOW-SOPT-SERVER/jinkonu/blob/c40028b6484dbf77f618c71b5e69ce34fe045ef3/sixthAssignment/src/main/java/org/sopt/service/MemberService.java#L52-L58

- redis에 저장된 값을 사용하지 않고, 리프레쉬 토큰을 파싱해서 사용자의 id를 조회했습니다.

&nbsp;
&nbsp;

# 🥷 API 테스트 결과
<img width="839" alt="image" src="https://github.com/NOW-SOPT-SERVER/jinkonu/assets/137763434/d779e507-a21e-46a8-a1bf-0190bbb972d6">

&nbsp;
&nbsp;

<img width="666" alt="image" src="https://github.com/NOW-SOPT-SERVER/jinkonu/assets/137763434/ab182277-b715-400f-be2a-bf31df5d71fd">

&nbsp;
&nbsp;
 
# ⁉️질문사항
- 리프레쉬 토큰을 Redis라는 데이터베이스에 저장하게 된다면, 세션 기반의 사용자 인증과 동일하게 사용자 인증 정보를 서버가 유지해야 한다는 단점을 지게 되는 것이 아닌지 궁금하네요!